### PR TITLE
BATS tests, Travis-CI and CodeClimate configuration

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,10 @@
+engines:
+  shellcheck:
+    enabled: true
+  markdownlint:
+    enabled: true
+ratings:
+  paths:
+    - "geo"
+    - "**.md"
+    - "test/fixtures/**"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: bash
+before_install:
+  - sudo add-apt-repository ppa:duggan/bats --yes
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq bats
+script:
+  - bats test
+

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@
 
 ![Imgur](http://i.imgur.com/aAtNFel.png)
 
+## Testing
+Install `bats` and execute `bats test/*`
+
 ## FAQ's / Contact
 * If you run into any issues, please open an issue ASAP and I'll work to get it resolved and merged.
 * Terminal used is [Hyper.js](https://hyper.is/) -> Background Color: #292937

--- a/test/darwin.bats
+++ b/test/darwin.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+
+setup() {
+  export PATH=test/fixtures/darwin:test/fixtures:$PATH
+}
+
+
+@test "Darwin WAN IP" {
+  run ./geo -w
+  [ "$status" -eq 0 ]
+  [ "$output" = "2.2.3.4" ]
+}
+
+@test "Darwin LAN IP" {
+  run ./geo -l
+  [ "$status" -eq 0 ]
+  [ "$output" = "2.2.3.4" ]
+}
+
+@test "Darwin Route IP" {
+  run ./geo -r
+  [ "$status" -eq 0 ]
+  [ "$output" = "2.2.3.1" ]
+}
+
+@test "Darwin IP Geodata" {
+  run ./geo -g
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "United States" ]
+  [ "${lines[1]}" = "NY" ]
+  [ "${lines[2]}" = "New York" ]
+  [ "${lines[3]}" = "10011" ]
+  [ "${lines[4]}" = "Digital Ocean" ]
+  [ "${lines[5]}" = "1.2.3.4" ]
+}
+
+@test "Darwin IP Selective Geodata" {
+  run ./geo -a 8.8.8.8 -o city
+  [ "$status" -eq 0 ]
+  [ "$output" = "Mountain View" ]
+}

--- a/test/fixtures/curl
+++ b/test/fixtures/curl
@@ -1,0 +1,13 @@
+#!/bin/sh
+if [ "$*" = "-sf http://ip-api.com/line/?fields=query,city,region,country,zip,isp" ]; then
+  echo "United States
+NY
+New York
+10011
+Digital Ocean
+1.2.3.4"
+fi
+
+if [ "$*" = "-sf http://ip-api.com/line/8.8.8.8?fields=city" ]; then
+  echo "Mountain View"
+fi

--- a/test/fixtures/darwin/dig
+++ b/test/fixtures/darwin/dig
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if [ "$*" = "+short myip.opendns.com @resolver1.opendns.com" ]; then
+  echo 2.2.3.4
+fi

--- a/test/fixtures/darwin/ifconfig
+++ b/test/fixtures/darwin/ifconfig
@@ -1,0 +1,51 @@
+#!/bin/sh
+echo "lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> mtu 16384
+	options=3<RXCSUM,TXCSUM>
+	inet6 ::1 prefixlen 128
+	inet 127.0.0.1 netmask 0xff000000
+	inet6 fe80::1%lo0 prefixlen 64 scopeid 0x1
+	nd6 options=1<PERFORMNUD>
+gif0: flags=8010<POINTOPOINT,MULTICAST> mtu 1280
+stf0: flags=0<> mtu 1280
+en0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
+	ether 11:11:11:11:11:11
+	inet6 fe80::1111:111:1111:111b%en0 prefixlen 64 scopeid 0x4
+	inet 2.2.3.4 netmask 0xffffff00 broadcast 2.2.3.255
+	nd6 options=1<PERFORMNUD>
+	media: autoselect
+	status: active
+en1: flags=963<UP,BROADCAST,SMART,RUNNING,PROMISC,SIMPLEX> mtu 1500
+	options=60<TSO4,TSO6>
+	ether 22:22:22:22:22:22
+	media: autoselect <full-duplex>
+	status: inactive
+en2: flags=963<UP,BROADCAST,SMART,RUNNING,PROMISC,SIMPLEX> mtu 1500
+	options=60<TSO4,TSO6>
+	ether 33:33:33:33:33:33
+	media: autoselect <full-duplex>
+	status: inactive
+bridge0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
+	options=63<RXCSUM,TXCSUM,TSO4,TSO6>
+	ether 44:44:44:44:44:44
+	Configuration:
+		id 0:0:0:0:0:0 priority 0 hellotime 0 fwddelay 0
+		maxage 0 holdcnt 0 proto stp maxaddr 100 timeout 1200
+		root id 0:0:0:0:0:0 priority 0 ifcost 0 port 0
+		ipfilter disabled flags 0x2
+	member: en1 flags=3<LEARNING,DISCOVER>
+	        ifmaxaddr 0 port 5 priority 0 path cost 0
+	member: en2 flags=3<LEARNING,DISCOVER>
+	        ifmaxaddr 0 port 6 priority 0 path cost 0
+	nd6 options=1<PERFORMNUD>
+	media: <unknown type>
+	status: inactive
+p2p0: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> mtu 2304
+	ether 55:55:55:55:55:55
+	media: autoselect
+	status: inactive
+awdl0: flags=8943<UP,BROADCAST,RUNNING,PROMISC,SIMPLEX,MULTICAST> mtu 1484
+	ether 66:66:66:66:66:66
+	inet6 fe80::6666:6666:6666:6666%awdl0 prefixlen 64 scopeid 0xa
+	nd6 options=1<PERFORMNUD>
+	media: autoselect
+	status: active"

--- a/test/fixtures/darwin/netstat
+++ b/test/fixtures/darwin/netstat
@@ -1,0 +1,22 @@
+#!/bin/sh
+if [ "$*" = "-rn" ]; then
+  echo "Routing tables
+
+Internet:
+Destination        Gateway            Flags        Refs      Use   Netif Expire
+default            2.2.3.1            UGSc           60        0     en0
+127                127.0.0.1          UCS             1        0     lo0
+127.0.0.1          127.0.0.1          UH             24 34170957     lo0
+169.254            link#4             UCS             1        0     en0
+192.168.1          link#4             UCS            11        0     en0
+192.168.1.1/32     link#4             UCS             2        0     en0
+192.168.1.1        22:22:22:22:22:22  UHLWIir        61      388     en0   1154
+
+Internet6:
+Destination                             Gateway                         Flags         Netif Expire
+::1                                     ::1                             UHL             lo0
+fe80::%lo0/64                           fe80::1%lo0                     UcI             lo0
+fe80::1%lo0                             link#1                          UHLI            lo0
+fe80::%en0/64                           link#4                          UCI             en0
+ff02::%awdl0/32                         link#10                         UmCI          awdl0"
+fi

--- a/test/fixtures/darwin/uname
+++ b/test/fixtures/darwin/uname
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo Darwin

--- a/test/fixtures/linux/dig
+++ b/test/fixtures/linux/dig
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if [ "$*" = "+short myip.opendns.com @resolver1.opendns.com" ]; then
+  echo 1.2.3.4
+fi

--- a/test/fixtures/linux/ip
+++ b/test/fixtures/linux/ip
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+if [ "$*" = "addr show" ]; then
+echo "1: lo: <LOOPBACK,UP,LOWER_UP> mtu 16436 qdisc noqueue state UNKNOWN
+    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
+    inet 127.0.0.1/8 scope host lo
+    inet6 ::1/128 scope host
+       valid_lft forever preferred_lft forever
+2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
+    link/ether 01:01:01:00:00:01 brd ff:ff:ff:ff:ff:ff
+    inet 1.2.3.5/24 brd 1.2.3.0 scope global eth0
+    inet6 2600:a000:0:1000::20:0001/64 scope global
+       valid_lft forever preferred_lft forever
+    inet6 fe80::600:010f:f000:0001/64 scope link
+       valid_lft forever preferred_lft forever"
+fi
+
+if [ "$*" = "route" ]; then
+echo "1.2.3.0/24 dev eth0  proto kernel  scope link  src 1.2.3.4
+169.254.0.0/16 dev eth0  scope link  metric 1002
+default via 1.2.3.1 dev eth0
+"
+fi

--- a/test/fixtures/linux/uname
+++ b/test/fixtures/linux/uname
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo Linux

--- a/test/linux.bats
+++ b/test/linux.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+
+setup() {
+  export PATH=test/fixtures/linux:test/fixtures:$PATH
+}
+
+
+@test "Linux WAN IP" {
+  run ./geo -w
+  [ "$status" -eq 0 ]
+  [ "$output" = "1.2.3.4" ]
+}
+
+@test "Linux LAN IP" {
+  run ./geo -l
+  [ "$status" -eq 0 ]
+  [ "$output" = "1.2.3.5" ]
+}
+
+@test "Linux Route IP" {
+  run ./geo -r
+  [ "$status" -eq 0 ]
+  [ "$output" = "1.2.3.1" ]
+}
+
+@test "Linux IP Geodata" {
+  run ./geo -g
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "United States" ]
+  [ "${lines[1]}" = "NY" ]
+  [ "${lines[2]}" = "New York" ]
+  [ "${lines[3]}" = "10011" ]
+  [ "${lines[4]}" = "Digital Ocean" ]
+  [ "${lines[5]}" = "1.2.3.4" ]
+}
+
+@test "Linux IP Selective Geodata" {
+  run ./geo -a 8.8.8.8 -o city
+  [ "$status" -eq 0 ]
+  [ "$output" = "Mountain View" ]
+}


### PR DESCRIPTION
I've added a set of BATS tests and test fixtures that emulate a Linux (Centos 6.8 in this case) and Darwin (El Capitan) outputs, and tests that look for the expected result.

Additionally I've added a Travis-CI configuration file. You can see what this looks like at https://travis-ci.org/jhmartin/Geo. It is free and you should be able to just sign in with your GitHub credentials and enable this repo, after which it will automatically run the tests on each commit and PR and annotate them with the result.

I've also added a CodeClimate configuration, which is another free service linked to GitHub. This is configured to run ShellCheck and MarkdownLint against it. You can see an example at https://codeclimate.com/github/jhmartin/Geo. Again you'll have to sign in and enable this repo.

Once you have Travis and CC enabled you can add build-badges to your README showing their state as well.